### PR TITLE
feat: add mockTips config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -41,6 +41,7 @@ const config = {
     result: ['result'], // 结果字段
     total: ['total', 0], // 列表总数字段，默认值
   },
+  mockTips: '请注意这个是mock接口～', // mock接口时的提醒，设置为false时不显示
 }
 
 // 覆盖配置

--- a/src/response.js
+++ b/src/response.js
@@ -34,7 +34,7 @@ async function respBody(ctx) {
       Mock.mock(ctx.body)
     }
     try {
-      let res = JSON.stringify(ctx.body || {}, null, config.jsonFormat ? '  ' : null)
+      let res = JSON.stringify(Object.assign(ctx.body || {}, config.mockTips !== false && {mockTips: config.mockTips}), null, config.jsonFormat ? '  ' : null)
       ctx.body = ctx.type === 'jsonp' ? `${callback}(${res})` : res
     } catch (error) {
       console.log(error)


### PR DESCRIPTION
增加了一个mockTips的配置，用于区别mock假数据接口

我遇到了这么个场景，使用mock和proxy同时用，mock数据和真实数据我没法区分

在config中增加了mockTips字段，默认mock会加入一个mockTips字段提醒，也可以修改为false不提醒